### PR TITLE
2025.10.27-release+2405

### DIFF
--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## PINNED TESTNET VERSION
-pinned_version="2024.4.21-release+858"
+pinned_version="2025.10.27-release+2405"
 ## END PINNED TESTNET VERSION
 
 echo ""


### PR DESCRIPTION
Updated the pinned testnet version to 2025.10.27-release+2405.