### PR TITLE
Update regex for build number matching in script

### DIFF
--- a/xahaud-install-update.sh
+++ b/xahaud-install-update.sh
@@ -129,7 +129,7 @@ if [[ "$FIRST_RUN" == true ]]; then
 fi
 
 log "Fetching latest version of $PROGRAM..."
-filenames=$(curl --silent "${URL}" | grep -Eo '>[^<]+<' | sed -e 's/^>//' -e 's/<$//' | grep -E '^\S+\+[0-9]{2,3}$' | grep -E $RELEASE_TYPE)
+filenames=$(curl --silent "${URL}" | grep -Eo '>[^<]+<' | sed -e 's/^>//' -e 's/<$//' | grep -E '^\S+\+[0-9]{2,4}$' | grep -E $RELEASE_TYPE)
 
 # If files were found, sort them and download the latest one if it hasn't already been downloaded
 if [[ -n $filenames ]]; then


### PR DESCRIPTION
Before the change, `2024.9.11-release+985` matched, but `2024.10.15-release+1020` did not.
This will be fixed.